### PR TITLE
Move css loading to _document

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -22,6 +22,10 @@ class CustomDocument extends Document {
               __html: JSON.stringify(AuthUserInfo, null, 2),
             }}
           />
+          <link
+            rel="stylesheet"
+            href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css"
+          />
         </Head>
         <body>
           <Main />

--- a/pages/characters/index.js
+++ b/pages/characters/index.js
@@ -2,7 +2,6 @@ import useSWR from 'swr';
 import Characters from '../../components/Characters/Characters';
 import Header from '../../components/Header/Header';
 import Nav from '../../components/Nav/Nav';
-import Head from 'next/head';
 import { Container, Table } from 'semantic-ui-react';
 // import SpeciesButtons from '../../components/SpeciesButtons/SpeciesButtons';
 
@@ -27,12 +26,6 @@ export default function characters() {
 
   return (
     <div className="container">
-      <Head>
-        <link
-          rel="stylesheet"
-          href="//cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css"
-        />
-      </Head>
       <Header />
       <Nav />
       {/* <SpeciesButtons /> */}


### PR DESCRIPTION
You should be able to delete the Head thing from all your other individual pages. 

This should prevent that flash of unstyled content whenever you load a page that uses semantic css. Like on the /characters page, the table loads unstyled briefly before "flashing" to the styled version. That's because the `semantic.min.css` hasnt loaded yet. This should fix that.